### PR TITLE
Fixed some installer glitches

### DIFF
--- a/~LoadMapSAREXTools10_0.bat
+++ b/~LoadMapSAREXTools10_0.bat
@@ -5,19 +5,19 @@ If Not DEFINED ProgramFiles(x86) Set _programs=%ProgramFiles%
 
 ECHO %_programs%
 
-xcopy "c:\Mapsar_Ex\tools\addins\*.esriaddin" "%_programs%\ArcGIS\Desktop10.0\bin\Addins\"
+set _igtpath=%~dp0
 
-xcopy "c:\Mapsar_Ex\tools\SAR_Toolbox100.tbx" "%_programs%\ArcGIS\Desktop10.0\ArcToolbox\Toolboxes\"
+xcopy "%_igtpath%tools\addins\*.esriaddin" "%_programs%\ArcGIS\Desktop10.0\bin\Addins\"
 
-IF NOT EXIST %APPDATA%\ArcGIS4LocalGovernment\ConfigFiles (
-   MKDIR %APPDATA%\ArcGIS4LocalGovernment\ConfigFiles"
+xcopy "%_igtpath%tools\SAR_Toolbox100.tbx" "%_programs%\ArcGIS\Desktop10.0\ArcToolbox\Toolboxes\"
+
+set _config="%APPDATA%\ArcGIS4LocalGovernment\ConfigFiles"
+IF NOT EXIST %_config% (
+   MKDIR %_config%
 )
-copy c:\mapsar_ex\tools\aaloaded.config %APPDATA%\ArcGIS4LocalGovernment\ConfigFiles\loaded.config /y
+copy "%_igtpath%tools\aaloaded.config" %_config%\loaded.config /y
 
-cd %_programs%\Common Files\ArcGIS\bin
+set _regasmdir="%_programs%\Common Files\ArcGIS\bin\"
+start "Register Measure Angle Addin" /D%_regasmdir% /W %_regasmdir%\ESRIRegAsm /p:Desktop "%_igtpath%Tools\AddIns\MeasureAngle.dll"
 
-ESRIRegAsm /p:Desktop "C:\MapSAR_Ex\Tools\AddIns\MeasureAngle.dll"
-
-cd \
-
-c:\mapsar_ex\tools\geomag-0.9.win32.exe
+"%_igtpath%tools\geomag-0.9.win32.exe"

--- a/~LoadMapSAREXTools10_1.bat
+++ b/~LoadMapSAREXTools10_1.bat
@@ -5,19 +5,19 @@ If Not DEFINED ProgramFiles(x86) Set _programs=%ProgramFiles%
 
 ECHO %_programs%
 
-xcopy "c:\Mapsar_Ex\tools\addins\*.esriaddin" "%_programs%\ArcGIS\Desktop10.1\bin\Addins\"
+set _igtpath=%~dp0
 
-xcopy "c:\Mapsar_Ex\tools\SAR_Toolbox100.tbx" "%_programs%\ArcGIS\Desktop10.1\ArcToolbox\Toolboxes\"
+xcopy "%_igtpath%tools\addins\*.esriaddin" "%_programs%\ArcGIS\Desktop10.1\bin\Addins\"
 
-IF NOT EXIST %APPDATA%\ArcGIS4LocalGovernment\ConfigFiles (
-   MKDIR %APPDATA%\ArcGIS4LocalGovernment\ConfigFiles"
+xcopy "%_igtpath%tools\SAR_Toolbox100.tbx" "%_programs%\ArcGIS\Desktop10.1\ArcToolbox\Toolboxes\"
+
+set _config="%APPDATA%\ArcGIS4LocalGovernment\ConfigFiles"
+IF NOT EXIST %_config% (
+   MKDIR %_config%
 )
-copy c:\mapsar_ex\tools\aaloaded.config %APPDATA%\ArcGIS4LocalGovernment\ConfigFiles\loaded.config /y
+copy "%_igtpath%tools\aaloaded.config" %_config%\loaded.config /y
 
-cd %_programs%\Common Files\ArcGIS\bin
+set _regasmdir="%_programs%\Common Files\ArcGIS\bin\"
+start "Register Measure Angle Addin" /D%_regasmdir% /W %_regasmdir%\ESRIRegAsm /p:Desktop "%_igtpath%Tools\AddIns\MeasureAngle.dll"
 
-ESRIRegAsm /p:Desktop "C:\MapSAR_Ex\Tools\AddIns\MeasureAngle.dll"
-
-cd \
-
-c:\mapsar_ex\tools\geomag-0.9.win32.exe
+"%_igtpath%tools\geomag-0.9.win32.exe"

--- a/~LoadMapSAREXTools10_2.bat
+++ b/~LoadMapSAREXTools10_2.bat
@@ -5,20 +5,19 @@ If Not DEFINED ProgramFiles(x86) Set _programs=%ProgramFiles%
 
 ECHO %_programs%
 
-xcopy "c:\Mapsar_Ex\tools\addins\*.esriaddin" "%_programs%\ArcGIS\Desktop10.2\bin\Addins\"
+set _igtpath=%~dp0
 
-xcopy "c:\Mapsar_Ex\tools\SAR_Toolbox100.tbx" "%_programs%\ArcGIS\Desktop10.2\ArcToolbox\Toolboxes\"
+xcopy "%_igtpath%tools\addins\*.esriaddin" "%_programs%\ArcGIS\Desktop10.2\bin\Addins\"
 
-IF NOT EXIST %APPDATA%\ArcGIS4LocalGovernment\ConfigFiles (
-   MKDIR %APPDATA%\ArcGIS4LocalGovernment\ConfigFiles"
+xcopy "%_igtpath%tools\SAR_Toolbox100.tbx" "%_programs%\ArcGIS\Desktop10.2\ArcToolbox\Toolboxes\"
+
+set _config="%APPDATA%\ArcGIS4LocalGovernment\ConfigFiles"
+IF NOT EXIST %_config% (
+   MKDIR %_config%
 )
-copy c:\mapsar_ex\tools\aaloaded.config %APPDATA%\ArcGIS4LocalGovernment\ConfigFiles\loaded.config /y
+copy "%_igtpath%tools\aaloaded.config" %_config%\loaded.config /y
 
-cd %_programs%\Common Files\ArcGIS\bin
+set _regasmdir="%_programs%\Common Files\ArcGIS\bin\"
+start "Register Measure Angle Addin" /D%_regasmdir% /W %_regasmdir%\ESRIRegAsm /p:Desktop "%_igtpath%Tools\AddIns\MeasureAngle.dll"
 
-ESRIRegAsm /p:Desktop "C:\MapSAR_Ex\Tools\AddIns\MeasureAngle.dll"
-
-cd \
-
-c:\mapsar_ex\tools\geomag-0.9.win32.exe
-
+"%_igtpath%tools\geomag-0.9.win32.exe"

--- a/~UninstallMapSAREXTools10_0.bat
+++ b/~UninstallMapSAREXTools10_0.bat
@@ -16,7 +16,6 @@ del "%_programs%\ArcGIS\Desktop10.0\ArcToolbox\Toolboxes\SAR_Toolbox100.tbx"
 
 del "%APPDATA%\ArcGIS4LocalGovernment\ConfigFiles\loaded.config"
 
-cd %_programs%\Common Files\ArcGIS\bin
-
-ESRIRegAsm /p:Desktop /u "C:\MapSAR_Ex\Tools\AddIns\MeasureAngle.dll"
-
+set _igtpath=%~dp0
+set _regasmdir="%_programs%\Common Files\ArcGIS\bin\"
+start "Unregister Measure Angle Addin" /D%_regasmdir% /W %_regasmdir%\ESRIRegAsm /p:Desktop /u "%_igtpath%Tools\AddIns\MeasureAngle.dll"

--- a/~UninstallMapSAREXTools10_1.bat
+++ b/~UninstallMapSAREXTools10_1.bat
@@ -16,7 +16,6 @@ del "%_programs%\ArcGIS\Desktop10.1\ArcToolbox\Toolboxes\SAR_Toolbox100.tbx"
 
 del "%APPDATA%\ArcGIS4LocalGovernment\ConfigFiles\loaded.config"
 
-cd %_programs%\Common Files\ArcGIS\bin
-
-ESRIRegAsm /p:Desktop /u "C:\MapSAR_Ex\Tools\AddIns\MeasureAngle.dll"
-
+set _igtpath=%~dp0
+set _regasmdir="%_programs%\Common Files\ArcGIS\bin\"
+start "Unregister Measure Angle Addin" /D%_regasmdir% /W %_regasmdir%\ESRIRegAsm /p:Desktop /u "%_igtpath%Tools\AddIns\MeasureAngle.dll"

--- a/~UninstallMapSAREXTools10_2.bat
+++ b/~UninstallMapSAREXTools10_2.bat
@@ -16,7 +16,6 @@ del "%_programs%\ArcGIS\Desktop10.2\ArcToolbox\Toolboxes\SAR_Toolbox100.tbx"
 
 del "%APPDATA%\ArcGIS4LocalGovernment\ConfigFiles\loaded.config"
 
-cd %_programs%\Common Files\ArcGIS\bin
-
-ESRIRegAsm /p:Desktop /u "C:\MapSAR_Ex\Tools\AddIns\MeasureAngle.dll"
-
+set _igtpath=%~dp0
+set _regasmdir="%_programs%\Common Files\ArcGIS\bin\"
+start "Unregister Measure Angle Addin" /D%_regasmdir% /W %_regasmdir%\ESRIRegAsm /p:Desktop /u "%_igtpath%Tools\AddIns\MeasureAngle.dll"


### PR DESCRIPTION
Also modified to allow installing in locations other than c:\MapSAR_Ex. Note: other IGT4SAR components still require installation in c:\MapSAR_Ex.
