### PR TITLE
Fix error in uninstaller for 10.4, update installer and uninstaller for 10.5 and 10.6

### DIFF
--- a/~LoadMapSAREXTools.bat
+++ b/~LoadMapSAREXTools.bat
@@ -36,6 +36,7 @@ IF EXIST "%_programs%\ArcGIS\Desktop10.1\License" CALL :install "%_programs%\Arc
 IF EXIST "%_programs%\ArcGIS\Desktop10.2\License" CALL :install "%_programs%\ArcGIS\Desktop10.2"
 IF EXIST "%_programs%\ArcGIS\Desktop10.3\License" CALL :install "%_programs%\ArcGIS\Desktop10.3"
 IF EXIST "%_programs%\ArcGIS\Desktop10.4\License" CALL :install "%_programs%\ArcGIS\Desktop10.4"
+IF EXIST "%_programs%\ArcGIS\Desktop10.5\License" CALL :install "%_programs%\ArcGIS\Desktop10.5"
 
 set _config="%APPDATA%\ArcGIS4LocalGovernment\ConfigFiles"
 IF NOT EXIST %_config% (

--- a/~LoadMapSAREXTools.bat
+++ b/~LoadMapSAREXTools.bat
@@ -37,6 +37,7 @@ IF EXIST "%_programs%\ArcGIS\Desktop10.2\License" CALL :install "%_programs%\Arc
 IF EXIST "%_programs%\ArcGIS\Desktop10.3\License" CALL :install "%_programs%\ArcGIS\Desktop10.3"
 IF EXIST "%_programs%\ArcGIS\Desktop10.4\License" CALL :install "%_programs%\ArcGIS\Desktop10.4"
 IF EXIST "%_programs%\ArcGIS\Desktop10.5\License" CALL :install "%_programs%\ArcGIS\Desktop10.5"
+IF EXIST "%_programs%\ArcGIS\Desktop10.6\License" CALL :install "%_programs%\ArcGIS\Desktop10.6"
 
 set _config="%APPDATA%\ArcGIS4LocalGovernment\ConfigFiles"
 IF NOT EXIST %_config% (

--- a/~UninstallMapSAREXTools.bat
+++ b/~UninstallMapSAREXTools.bat
@@ -35,6 +35,7 @@ IF EXIST "%_programs%\ArcGIS\Desktop10.2\License" CALL :remove "%_programs%\ArcG
 IF EXIST "%_programs%\ArcGIS\Desktop10.3\License" CALL :remove "%_programs%\ArcGIS\Desktop10.3"
 IF EXIST "%_programs%\ArcGIS\Desktop10.4\License" CALL :remove "%_programs%\ArcGIS\Desktop10.4"
 IF EXIST "%_programs%\ArcGIS\Desktop10.5\License" CALL :remove "%_programs%\ArcGIS\Desktop10.5"
+IF EXIST "%_programs%\ArcGIS\Desktop10.6\License" CALL :remove "%_programs%\ArcGIS\Desktop10.6"
 
 del "%APPDATA%\ArcGIS4LocalGovernment\ConfigFiles\loaded.config"
 

--- a/~UninstallMapSAREXTools.bat
+++ b/~UninstallMapSAREXTools.bat
@@ -33,7 +33,7 @@ IF EXIST "%_programs%\ArcGIS\Desktop10.0\License" CALL :remove "%_programs%\ArcG
 IF EXIST "%_programs%\ArcGIS\Desktop10.1\License" CALL :remove "%_programs%\ArcGIS\Desktop10.1"
 IF EXIST "%_programs%\ArcGIS\Desktop10.2\License" CALL :remove "%_programs%\ArcGIS\Desktop10.2"
 IF EXIST "%_programs%\ArcGIS\Desktop10.3\License" CALL :remove "%_programs%\ArcGIS\Desktop10.3"
-IF EXIST "%_programs%\ArcGIS\Desktop10.1\License" CALL :remove "%_programs%\ArcGIS\Desktop10.4"
+IF EXIST "%_programs%\ArcGIS\Desktop10.4\License" CALL :remove "%_programs%\ArcGIS\Desktop10.4"
 
 del "%APPDATA%\ArcGIS4LocalGovernment\ConfigFiles\loaded.config"
 

--- a/~UninstallMapSAREXTools.bat
+++ b/~UninstallMapSAREXTools.bat
@@ -34,6 +34,7 @@ IF EXIST "%_programs%\ArcGIS\Desktop10.1\License" CALL :remove "%_programs%\ArcG
 IF EXIST "%_programs%\ArcGIS\Desktop10.2\License" CALL :remove "%_programs%\ArcGIS\Desktop10.2"
 IF EXIST "%_programs%\ArcGIS\Desktop10.3\License" CALL :remove "%_programs%\ArcGIS\Desktop10.3"
 IF EXIST "%_programs%\ArcGIS\Desktop10.4\License" CALL :remove "%_programs%\ArcGIS\Desktop10.4"
+IF EXIST "%_programs%\ArcGIS\Desktop10.5\License" CALL :remove "%_programs%\ArcGIS\Desktop10.5"
 
 del "%APPDATA%\ArcGIS4LocalGovernment\ConfigFiles\loaded.config"
 


### PR DESCRIPTION
Fix error in installer/uninstaller

The new line for installation/uninstallation with ArcGIS 10.4 had:

IF EXIST "%_programs%\ArcGIS\Desktop10.3\License" CALL :install \
    "%_programs%\ArcGIS\Desktop10.4"

instead of

IF EXIST "%_programs%\ArcGIS\Desktop10.4\License" CALL :install \
    "%_programs%\ArcGIS\Desktop10.4"
