### PR TITLE
Fix NMSAR 204 team members population

### DIFF
--- a/Tools/Scripts/IGT4SAR_CreateICS204.py
+++ b/Tools/Scripts/IGT4SAR_CreateICS204.py
@@ -341,11 +341,11 @@ def NMSAR(Assign, Team, TeamMember, AssNum, incidInfo, output, OpPeriod,TAF2Use)
                 fdfFields['Skill  Equipment1']=str(TeamMember[key][2]) # LeadSkill
                 kk+=1
             else:
-                memName = 'Name{0}'.format(k)
+                memName = 'Name{0}'.format(k+1)
                 fdfFields[memName]=str(key) # Member
-                resName ='Resource Name TL Comm Navigator{0}'.format(k)
+                resName ='Resource Name TL Comm Navigator{0}'.format(k+1)
                 fdfFields[resName]=str(TeamMember[key][3]) # Resource
-                skilEq = 'Skill Equipment{0}'.format(k)
+                skilEq = 'Skill Equipment{0}'.format(k+1)
                 fdfFields[skilEq] = str(TeamMember[key][2]) # Skill
                 k+=1
             if k>7:


### PR DESCRIPTION
The NMSAR ICS 204 form does not have all of its team member fields labeled
in a rational order.  The team leader's name field is called "Text1" and
subsequent team member names are in fields called Name{n} where n ranges
from 2 through 8.  The resource name and skill fields are all identically
named with only the suffix 1-8 changing --- the 1 pertains to the team
leader.

As written originally, the code tried to stuff team members 2-8 into
fields 1-7, and the result was team members missing from the assignment
form.

This commit fixes the error, making sure that the team leader is put into
Text 1 (which was correct before) and not then overwritten by the next
team member (or made blank).  It also gets all the other members populated into the Name2-Name8 fields correctly.

This was tested with real mission data, after observing that the form was
wrong with the original code.